### PR TITLE
Remove ExperimentAway

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -106,11 +106,6 @@ hash = "4f689b450be11c0b9bf86d1f46b273eb57f08d19a22579a426d16d8364a706b4"
 metafile = true
 
 [[files]]
-file = "mods/experimentaway.toml"
-hash = "ecdb400b244e5e24179fba10aa8df220351556b4f0a64b5443a03d0ae80bd522"
-metafile = true
-
-[[files]]
 file = "mods/fabric-api.toml"
 hash = "b901e5c8264af78d27a7a96a2123a9404e26cf54badcc7c62006d130db50dcaf"
 metafile = true

--- a/mods/experimentaway.toml
+++ b/mods/experimentaway.toml
@@ -1,8 +1,0 @@
-name = "ExperimentAway"
-filename = "experimentaway-1.0.2.jar"
-side = "both"
-
-[download]
-url = "https://github.com/user11681/ExperimentAway/releases/download/1.0.2/experimentaway-1.0.2.jar"
-hash-format = "sha256"
-hash = "98fac7f98be33202ec38f8e481e0e4bbe709df624222e359409de6765bba4722"


### PR DESCRIPTION
I'm not sure exactly why but this mod breaks the New World screen. 