### PR TITLE
Fix Conflict

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -261,6 +261,11 @@ hash = "506d4d6e17ab74adbaf7980af075d87c69e488d39fc33b68b2751bed24c9fd66"
 metafile = true
 
 [[files]]
+file = "mods/nbt-crafting.toml"
+hash = "79078e38d1e7d836b40fff447c84b38428a6c738848e48ee0e8f1ed2bb602aa7"
+metafile = true
+
+[[files]]
 file = "mods/netherite-plus-mod.toml"
 hash = "b5b6a237b82ea7ad69319276691018b57b979b157895e8c5af45daee3141d35d"
 metafile = true

--- a/mods/nbt-crafting.toml
+++ b/mods/nbt-crafting.toml
@@ -1,0 +1,14 @@
+name = "Nbt Crafting (Fabric)"
+filename = "nbtcrafting-2.0.3+mc1.16.4.jar"
+side = "both"
+
+[download]
+url = "https://edge.forgecdn.net/files/3145/245/nbtcrafting-2.0.3+mc1.16.4.jar"
+hash-format = "murmur2"
+hash = "3750173357"
+
+[update]
+[update.curseforge]
+file-id = 3145245
+project-id = 314633
+release-channel = "beta"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ version = ""
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "448eb59ab2b9792b38fce40f03ad82d2c98cf441205b471a275ec9037860663f"
+hash = "7b123896248f6bbe27acd38521b8f639deeadaec523463c14a6c75e23d4c54ae"
 
 [versions]
 fabric = "0.10.8"


### PR DESCRIPTION
## Reason
The `Carve My Pumpkin` mod JiJ's the `NBT Crafting` mod. But Cardinal Components (which is JiJ'd by another mod) conflicts with any version of NBTCrafting before `2.0.3` (Can be seen [here](https://github.com/OnyxStudios/Cardinal-Components-API/blob/master/cardinal-components-item/src/main/resources/fabric.mod.json#L18)).

Carve My Pumpkin JiJ's a version before `2.0.3`.

## This PR
This PR adds `NBTCrafting` to the pack, with version `2.0.3`. Since newer versions take precedence, Fabric Loader will load the non-conflicting version.