### PR TITLE
Fix Item scroller not working.

### DIFF
--- a/mods/item-scroller.toml
+++ b/mods/item-scroller.toml
@@ -1,11 +1,11 @@
+name = "Item Scroller"
+filename = "itemscroller-fabric-1.16.4-0.15.0-dev.20210111.205029.jar"
+side = "both"
+
 [option]
 optional = true
 description = "Easy item sorting. Don't use if you have Mouse Wheelie!"
 default = false
-
-name = "Item Scroller"
-filename = "itemscroller-fabric-1.16.4-0.15.0-dev.20210111.205029.jar"
-side = "both"
 
 [download]
 url = "https://edge.forgecdn.net/files/3168/57/itemscroller-fabric-1.16.4-0.15.0-dev.20210111.205029.jar"


### PR DESCRIPTION
The `name`, `filename` and `side` values were under the `option` group. They are now moved out.