### PR TITLE
Fixed broken FAPI dependency

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -177,7 +177,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.toml"
-hash = "629e68f5b1826bb31da6e7519de9b977bee17da75c1ff72998ef555cbb91017f"
+hash = "dcc84d3bc69e9bbcc3bdd5c8a18d5ceeb6943dde6918149d7bf92eca6485cbb0"
 metafile = true
 
 [[files]]

--- a/index.toml
+++ b/index.toml
@@ -177,7 +177,7 @@ metafile = true
 
 [[files]]
 file = "mods/fabric-api.toml"
-hash = "dcc84d3bc69e9bbcc3bdd5c8a18d5ceeb6943dde6918149d7bf92eca6485cbb0"
+hash = "301a380f82a36e49ad2e20b4a65e8aae044dc95ee529825d23da93af0b441985"
 metafile = true
 
 [[files]]

--- a/mods/fabric-api.toml
+++ b/mods/fabric-api.toml
@@ -3,12 +3,12 @@ filename = "fabric-api-0.30.0+1.16.jar"
 side = "both"
 
 [download]
-url = "https://media.forgecdn.net/files/3183/643/fabric-api-0.30.0%2B1.16.jar"
-hash-format = "md5"
-hash = "255a0a1c349282887d3bceb00f77acfb"
+url = "https://edge.forgecdn.net/files/3183/643/fabric-api-0.30.0+1.16.jar"
+hash-format = "murmur2"
+hash = "4291950913"
 
 [update]
 [update.curseforge]
 file-id = 3183643
 project-id = 306612
-release-channel = "release"
+release-channel = "beta"

--- a/mods/fabric-api.toml
+++ b/mods/fabric-api.toml
@@ -1,14 +1,14 @@
 name = "Fabric API"
-filename = "fabric-api-0.29.3+1.16.jar"
+filename = "fabric-api-0.30.0+1.16.jar"
 side = "both"
 
 [download]
-url = "https://edge.forgecdn.net/files/3159/126/fabric-api-0.29.3+1.16.jar"
-hash-format = "murmur2"
-hash = "1677674312"
+url = "https://media.forgecdn.net/files/3183/643/fabric-api-0.30.0%2B1.16.jar"
+hash-format = "md5"
+hash = "255a0a1c349282887d3bceb00f77acfb"
 
 [update]
 [update.curseforge]
-file-id = 3159126
+file-id = 3183643
 project-id = 306612
-release-channel = "beta"
+release-channel = "release"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ version = "2.0.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "756ea8b9ef1fdb8dca5214ef38ff074302eaa40acdc98a93b193844adce47fc6"
+hash = "50e116495eed9e85d41eeaf6678cd4d8c6a6d09b2199e4f4a53696513835dbc1"
 
 [versions]
 fabric = "0.10.8"

--- a/pack.toml
+++ b/pack.toml
@@ -5,7 +5,7 @@ version = "2.0.0"
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "50e116495eed9e85d41eeaf6678cd4d8c6a6d09b2199e4f4a53696513835dbc1"
+hash = "1146532386c9bd307b18ad41d064277f7fab4d506c7e43391d88245d8bb8c897"
 
 [versions]
 fabric = "0.10.8"


### PR DESCRIPTION
(should) fix packwiz giving FAPI 0.29.3, when Netherite Plus requires 0.30.0